### PR TITLE
JnLlnd's backreference bugfix

### DIFF
--- a/Hotstring.ahk
+++ b/Hotstring.ahk
@@ -135,8 +135,8 @@ Hotstring(trigger, label, mode := 1, clearTrigger := 1, cond := ""){
 					toSend := v.label
 				
 					;Working out the backreferences
-					Loop, % local$.Count()
-						StringReplace, toSend,toSend,% "$" . A_Index,% local$.Value(A_index),All
+					Loop, % local$.Count()+1
+						StringReplace, toSend,toSend,% "$" . A_Index-1,% local$.Value(A_index-1),All
 					toSend := RegExReplace(toSend,"([!#\+\^\{\}])","{$1}") ;Escape modifiers
 					SendInput,%toSend%
 				}


### PR DESCRIPTION
this example in the readme fails:

```autohotkey
Hotstring("i)colou?rs","$0 $0 everywhere!", 3) ; Regex, Case insensitive
; colors -> 'colors colors everywhere!'
; colours -> 'colours colours everywhere!'
```

this PR fixes it using the fix from JnLlnd found here:

https://autohotkey.com/boards/viewtopic.php?p=192691#p192691