### PR TITLE
fix bug where case-sensitive hotstring wasn't being passed to label

### DIFF
--- a/Hotstring.ahk
+++ b/Hotstring.ahk
@@ -107,7 +107,7 @@ Hotstring(trigger, label, mode := 1, clearTrigger := 1, cond := ""){
 					A_LoopCond := Func(v.cond)
 					if (A_LoopCond.MinParams >= 1){
 						; If the function has atleast 1 parameters.
-						A_LoopRetVal := A_LoopCond.(v.mode == 3 ? local$ : local$.Value(0))
+						A_LoopRetVal := A_LoopCond.(v.mode == 1 ? local$.Value(0) : local$)
 					} else {
 						A_LoopRetVal := A_LoopCond.()
 					}
@@ -122,12 +122,12 @@ Hotstring(trigger, label, mode := 1, clearTrigger := 1, cond := ""){
 					SendInput % "{BS " . StrLen(local$.Value(0))  . "}"
 				}
 				if (IsLabel(v.label)){
-					$ := v.mode == 3 ? local$ : local$.Value(0)
+					$ := v.mode == 1 ? local$.Value(0) : local$
 					gosub, % v.label
 				} else if (IsFunc(v.label)){
 					callbackFunc := Func(v.label)
 					if (callbackFunc.MinParams >= 1){
-						callbackFunc.(v.mode == 3 ? local$ : local$.Value(0))
+						callbackFunc.(v.mode == 1 ? local$.Value(0) : local$)
 					} else {
 						callbackFunc.()
 					}


### PR DESCRIPTION
mentioned in issue #5

the following example was previously failing, but is fixed with this commit:

```autohotkey
Hotstring("Trigger2", "replace", 2)

replace($) {
    ; $ == 'trigger'
    MsgBox % "'" . $ . "' was entered!"
}
```
  